### PR TITLE
Changed react-ui dockerfile to use prod mode

### DIFF
--- a/react-ui/Dockerfile
+++ b/react-ui/Dockerfile
@@ -2,9 +2,10 @@ FROM node:16-bullseye-slim
 
 WORKDIR /app
 COPY package.json package-lock.json ./
-RUN npm install
-RUN chown -R node /app/node_modules
-COPY --chown=node:node . .
+COPY . .
+RUN npm ci
+RUN npm install -g serve@14
+RUN npm run build
 EXPOSE 3000
 USER node
-CMD ["npm", "start"]
+CMD ["serve", "-s", "build", "-l", "3000"]


### PR DESCRIPTION
# React UI Dockerfile production mode

## Changed React UI Dockerfile to use and serve production mode instead of dev

-----------------------------------------------------------------------------------------------
### Breakdown:

#### React UI Dockerfile
 1. react-ui/Dockerfile
     * React UI now builds and runs in prod mode