### PR TITLE
Changed react-ui docker to add a copy of main.js

### DIFF
--- a/react-ui/Dockerfile
+++ b/react-ui/Dockerfile
@@ -6,6 +6,8 @@ COPY . .
 RUN npm ci
 RUN npm install -g serve@14
 RUN npm run build
+RUN chmod +x create_mainjs_copy.sh
+RUN ./create_mainjs_copy.sh
 EXPOSE 3000
 USER node
 CMD ["serve", "-s", "build", "-l", "3000"]

--- a/react-ui/create_mainjs_copy.sh
+++ b/react-ui/create_mainjs_copy.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Define the target file path
+target_file="./build/static/js/main.js"
+
+# Use regex to find the source file with a changing hashed filename
+src_file=$(find ./build/static/js/ -regex ".*/main\.[a-zA-Z0-9]+\.js" -print -quit)
+
+# Check if the source file was found
+if [ -n "$src_file" ]; then
+  # Remove the existing target file if it exists
+  if [ -f "$target_file" ]; then
+    rm "$target_file"
+  fi
+
+  # Create a copy of the source file
+  cp "$src_file" "$target_file"
+
+  # Confirm the creation of the copy
+  echo "Copy created: $target_file <- $src_file"
+else
+  # Confirm that the source file was not found
+  echo "Error: source file not found"
+fi


### PR DESCRIPTION
# Dockerized react-ui main.js file without hash

## React-ui docker build creates a copy of main.js file without hash in filename

-----------------------------------------------------------------------------------------------
### Breakdown:

#### react-ui docker main.js
 1. react-ui/Dockerfile
     * Dockerfile executes main.js copy script
   
 2. react-ui/create_mainjs_copy.sh
     * script that makes a copy of hashed main.js file without the hash in the copy filename